### PR TITLE
Make flate2 dependency (and PNG encoding) optional

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ exclude = [
 
 [dependencies]
 inflate = "0.1.0"
-flate2 = "0.2.11"
+flate2 = { version = "0.2.11", optional = true }
 libc = "0.2.1"
 num = "0.1.27"
 bitflags = "0.3.2"
@@ -27,5 +27,6 @@ features = ["glutin"]
 default-features = false
 
 [features]
-default = []
+png-encoding = ["flate2"]
+default = ["png-encoding"]
 unstable = []

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,13 +1,13 @@
 //! # PNG encoder and decoder
 //! This crate contains a PNG decoder. It supports reading of single lines or whole frames.
 //! ## The decoder
-//! The most important types for decoding purposes are [`Decoder`](struct.Decoder.html) and 
+//! The most important types for decoding purposes are [`Decoder`](struct.Decoder.html) and
 //! [`Reader`](struct.Reader.html). They both wrap a `std::io::Read`.
-//! `Decoder` serves as a builder for `Reader`. Calling `Decoder::read_info` reads from the `Read` until the 
+//! `Decoder` serves as a builder for `Reader`. Calling `Decoder::read_info` reads from the `Read` until the
 //! image data is reached.
 //! ### Using the decoder
 //!     use std::fs::File;
-//! 
+//!
 //!     // The decoder is a build for reader and can be used to set various decoding options
 //!     // via `Transformations`. The default output transformation is `TRANSFORM_EXPAND
 //!     // | TRANSFORM_STRIP_ALPHA`.
@@ -16,7 +16,7 @@
 //!     // Allocate the output buffer.
 //!     let mut buf = vec![0; info.buffer_size()];
 //!     // Read the next frame. Currently this function should only called once.
-//!     // The default options 
+//!     // The default options
 //!     reader.next_frame(&mut buf).unwrap();
 //! ## Encoder
 //! Not available yet
@@ -30,6 +30,7 @@ extern crate num;
 pub mod chunk;
 mod crc;
 mod decoder;
+#[cfg(feature = "png-encoding")]
 mod encoder;
 mod filter;
 mod traits;
@@ -38,6 +39,7 @@ mod utils;
 
 pub use common::*;
 pub use decoder::{Decoder, Reader, OutputInfo, StreamingDecoder, Decoded, DecodingError};
+#[cfg(feature = "png-encoding")]
 pub use encoder::{Encoder, Writer, EncodingError};
 
 pub use traits::{Parameter, HasParameters};


### PR DESCRIPTION
This allows pure-Rust PNG decoding