### PR TITLE
Update docs on encoder/writer and added example code for encoding

### DIFF
--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -50,6 +50,7 @@ impl From<EncodingError> for io::Error {
     }
 }
 
+/// PNG Encoder
 pub struct Encoder<W: Write> {
     w: W,
     info: Info,
@@ -88,6 +89,7 @@ impl<W: Write> Parameter<Encoder<W>> for BitDepth {
     }
 }
 
+/// PNG writer
 pub struct Writer<W: Write> {
     w: W,
     info: Info,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,5 @@
 //! # PNG encoder and decoder
-//! This crate contains a PNG decoder. It supports reading of single lines or whole frames.
+//! This crate contains a PNG encoder and decoder. It supports reading of single lines or whole frames.
 //! ## The decoder
 //! The most important types for decoding purposes are [`Decoder`](struct.Decoder.html) and
 //! [`Reader`](struct.Reader.html). They both wrap a `std::io::Read`.
@@ -19,7 +19,26 @@
 //!     // The default options
 //!     reader.next_frame(&mut buf).unwrap();
 //! ## Encoder
-//! Not available yet
+//! ### Using the encoder
+//!     // For reading and opening files
+//!     use std::path::Path;
+//!     use std::fs::File;
+//!     use std::io::BufWriter;
+//!     // To use encoder.set()
+//!     use png::HasParameters;
+//!
+//!     let path = Path::new(r"/path/to/image.png");
+//!     let file = File::create(path).unwrap();
+//!     let ref mut w = BufWriter::new(file);
+//!
+//!     let mut encoder = png::Encoder::new(w, 2, 1); // Width is 2 pixels and height is 1.
+//!     encoder.set(png::ColorType::RGBA).set(png::BitDepth::Eight);
+//!      let mut writer = encoder.write_header().unwrap();
+//!
+//!     let data = [255, 0, 0, 255, 0, 0, 0, 255]; // An array containing a RGBA sequence. First pixel is red and second pixel is black.
+//!     writer.write_image_data(&data).unwrap(); // Save
+//!
+//!
 //#![cfg_attr(test, feature(test))]
 
 #[macro_use] extern crate bitflags;


### PR DESCRIPTION
This adds information about the encoder in the docs with an example code on how to create a png file. Also adds a short description for encoder and writer. This will help avoid confusion from users too, related to this issue #42 