### PR TITLE
Use deflate rather than flate2 for deflate encoding. Fixes #2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ exclude = [
 
 [dependencies]
 inflate = "0.1.0"
-flate2 = { version = "0.2.11", optional = true }
+deflate = { version = "0.7.1", optional = true }
 num-iter = "0.1.32"
 bitflags = "0.7"
 
@@ -26,6 +26,6 @@ features = ["glutin"]
 default-features = false
 
 [features]
-png-encoding = ["flate2"]
+png-encoding = ["deflate"]
 default = ["png-encoding"]
 unstable = []


### PR DESCRIPTION
This changes the encoder to use deflate-rs, which is written in rust rather than flate2 which is wrapper to the c library miniz. This would fix #2.

I don't know if it should be merged yet, the roundtrip unit test seems to work fine, but it may need some more testing on other images. (There's a failing doc test, but it failed before I did any changes so I presume it's unrelated, as it complains about a missing file). I've tested the decoder on a fair number of different inputs, but there could still be bugs in it (but feel free to help out with the decoder if you find any). It's also going to be a bit slower than using flate2 for now.

My editor also ran rustfmt on the file I changed, so if that's an issue I'll change the PR to avoid that if you want.

Lastly, I wasn't sure if I should pin the full version, or if I should only depend on "0.7" to avoid having to update image-png in case of bugfixes to deflate.