### PR TITLE
Update bitflags 0.7 -> 0.9

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ exclude = [
 inflate = "0.2.0"
 deflate = { version = "0.7.2", optional = true }
 num-iter = "0.1.32"
-bitflags = "0.7"
+bitflags = "0.9"
 
 [dev-dependencies]
 getopts = "0.2.14"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "png"
-version = "0.7.0"
+version = "0.8.0"
 license = "MIT/Apache-2.0"
 description = "PNG decoding and encoding library in pure Rust"
 authors = ["nwin <nwin@users.noreply.github.com>"]

--- a/src/common.rs
+++ b/src/common.rs
@@ -207,39 +207,39 @@ bitflags! {
     /// # Output transformations
     ///
     /// Only `TRANSFORM_IDENTITY` and `TRANSFORM_EXPAND | TRANSFORM_STRIP_ALPHA` can be used at the moment.
-    pub flags Transformations: u32 {
+    pub struct Transformations: u32 {
         /// No transformation
-        const TRANSFORM_IDENTITY            = 0x0000, // read and write */
+        const TRANSFORM_IDENTITY            = 0x0000; // read and write */
         /// Strip 16-bit samples to 8 bits
-        const TRANSFORM_STRIP_16            = 0x0001, // read only */
+        const TRANSFORM_STRIP_16            = 0x0001; // read only */
         /// Discard the alpha channel
-        const TRANSFORM_STRIP_ALPHA         = 0x0002, // read only */
-        /// Expand 1, 2 and 4-bit samples to bytes
-        const TRANSFORM_PACKING             = 0x0004, // read and write */
+        const TRANSFORM_STRIP_ALPHA         = 0x0002; // read only */
+        /// Expand 1; 2 and 4-bit samples to bytes
+        const TRANSFORM_PACKING             = 0x0004; // read and write */
         /// Change order of packed pixels to LSB first
-        const TRANSFORM_PACKSWAP            = 0x0008, // read and write */
-        /// Expand paletted images to RGB, expand grayscale images of
-        /// less than 8-bit depth to 8-bit depth, and expand tRNS chunks
+        const TRANSFORM_PACKSWAP            = 0x0008; // read and write */
+        /// Expand paletted images to RGB; expand grayscale images of
+        /// less than 8-bit depth to 8-bit depth; and expand tRNS chunks
         /// to alpha channels.
-        const TRANSFORM_EXPAND              = 0x0010, // read only */
+        const TRANSFORM_EXPAND              = 0x0010; // read only */
         /// Invert monochrome images
-        const TRANSFORM_INVERT_MONO         = 0x0020, // read and write */
+        const TRANSFORM_INVERT_MONO         = 0x0020; // read and write */
         /// Normalize pixels to the sBIT depth
-        const TRANSFORM_SHIFT               = 0x0040, // read and write */
-        /// Flip RGB to BGR, RGBA to BGRA
-        const TRANSFORM_BGR                 = 0x0080, // read and write */
+        const TRANSFORM_SHIFT               = 0x0040; // read and write */
+        /// Flip RGB to BGR; RGBA to BGRA
+        const TRANSFORM_BGR                 = 0x0080; // read and write */
         /// Flip RGBA to ARGB or GA to AG
-        const TRANSFORM_SWAP_ALPHA          = 0x0100, // read and write */
+        const TRANSFORM_SWAP_ALPHA          = 0x0100; // read and write */
         /// Byte-swap 16-bit samples
-        const TRANSFORM_SWAP_ENDIAN         = 0x0200, // read and write */
+        const TRANSFORM_SWAP_ENDIAN         = 0x0200; // read and write */
         /// Change alpha from opacity to transparency
-        const TRANSFORM_INVERT_ALPHA        = 0x0400, // read and write */
-        const TRANSFORM_STRIP_FILLER        = 0x0800, // write only */
-        const TRANSFORM_STRIP_FILLER_BEFORE = 0x0800, // write only
-        const TRANSFORM_STRIP_FILLER_AFTER  = 0x1000, // write only */
-        const TRANSFORM_GRAY_TO_RGB         = 0x2000, // read only */ 
-        const TRANSFORM_EXPAND_16           = 0x4000, // read only */ 
-        const TRANSFORM_SCALE_16            = 0x8000, // read only */ 
+        const TRANSFORM_INVERT_ALPHA        = 0x0400; // read and write */
+        const TRANSFORM_STRIP_FILLER        = 0x0800; // write only */
+        const TRANSFORM_STRIP_FILLER_BEFORE = 0x0800; // write only
+        const TRANSFORM_STRIP_FILLER_AFTER  = 0x1000; // write only */
+        const TRANSFORM_GRAY_TO_RGB         = 0x2000; // read only */
+        const TRANSFORM_EXPAND_16           = 0x4000; // read only */
+        const TRANSFORM_SCALE_16            = 0x8000; // read only */
     }
 }
 


### PR DESCRIPTION
Hi,
We've encountered a dependency problem in https://github.com/brson/rust-cookbook/pull/192 due to outdated bitflags version here.