### PR TITLE
WindowEvent::Close to WindowEvent::CloseRequested

### DIFF
--- a/examples/show.rs
+++ b/examples/show.rs
@@ -88,7 +88,7 @@ fn main_loop(files: Vec<path::PathBuf>) -> io::Result<()> {
         events_loop.poll_events(|event| {
             if stop {return;}
             match event {
-                Event::WindowEvent {event: WindowEvent::Closed, ..} => {
+                Event::WindowEvent {event: WindowEvent::CloseRequested, ..} => {
                     stop = true;
                     return;
                 }


### PR DESCRIPTION
It was a breaking change in winit 0.13.0:

>Breaking: the Closed event has been replaced by CloseRequested and 
>Destroyed. To migrate, you typically just need to replace all usages of 
>Closed with CloseRequested; see example programs for more info.