### PR TITLE
Replace slice conversion with vec drain

### DIFF
--- a/src/decoder/mod.rs
+++ b/src/decoder/mod.rs
@@ -462,8 +462,7 @@ impl<R: Read> Reader<R> {
                         ))
                     }
                     self.prev[..rowlen].copy_from_slice(&self.current[..rowlen]);
-                    // TODO optimize
-                    self.current = self.current[rowlen..].into();
+                    self.current.drain(0..rowlen);
                     return Ok(
                         Some((
                             &self.prev[1..rowlen],


### PR DESCRIPTION
I was running into a memory issue on my end, and this fixed it. Incidentally should be more performant as well (no extra allocation).