### PR TITLE
[+] Allow caller to specify compression level via setter.

### DIFF
--- a/src/common.rs
+++ b/src/common.rs
@@ -1,4 +1,5 @@
 //! Common types shared between the encoder and decoder
+use filter;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
@@ -136,6 +137,7 @@ pub struct Info {
     pub frame_control: Option<FrameControl>,
     pub animation_control: Option<AnimationControl>,
     pub compression: deflate::CompressionOptions,
+    pub filter: filter::FilterType,
 }
 
 impl Default for Info {
@@ -151,8 +153,10 @@ impl Default for Info {
             pixel_dims: None,
             frame_control: None,
             animation_control: None,
-            // Default to `fast` to maintain backward compatible output. 
+            // Default to `deflate::Compresion::Fast` and `filter::FilterType::Sub` 
+            // to maintain backward compatible output. 
             compression: deflate::CompressionOptions::fast(),
+            filter: filter::FilterType::Sub,
         }
     }
 }

--- a/src/common.rs
+++ b/src/common.rs
@@ -134,7 +134,8 @@ pub struct Info {
     pub pixel_dims: Option<PixelDimensions>,
     pub palette: Option<Vec<u8>>,
     pub frame_control: Option<FrameControl>,
-    pub animation_control: Option<AnimationControl>
+    pub animation_control: Option<AnimationControl>,
+    pub compression: deflate::CompressionOptions,
 }
 
 impl Default for Info {
@@ -149,7 +150,9 @@ impl Default for Info {
             trns: None,
             pixel_dims: None,
             frame_control: None,
-            animation_control: None
+            animation_control: None,
+            // Default to `fast` to maintain backward compatible output. 
+            compression: deflate::CompressionOptions::fast(),
         }
     }
 }

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -81,6 +81,12 @@ impl<W: Write> Parameter<Encoder<W>> for BitDepth {
     }
 }
 
+impl<W: Write> Parameter<Encoder<W>> for deflate::CompressionOptions {
+    fn set_param(self, this: &mut Encoder<W>) {
+        this.info.compression = self
+    }
+}
+
 /// PNG writer
 pub struct Writer<W: Write> {
     w: W,
@@ -127,7 +133,7 @@ impl<W: Write> Writer<W> {
             let message = format!("wrong data size, expected {} got {}", data_size, data.len());
             return Err(EncodingError::Format(message.into()));
         }
-        let mut zlib = deflate::write::ZlibEncoder::new(Vec::new(), deflate::Compression::Fast);
+        let mut zlib = deflate::write::ZlibEncoder::new(Vec::new(), self.info.compression);
         let filter_method = FilterType::Sub;
         for line in data.chunks(in_len) {
             current.copy_from_slice(&line);

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -87,6 +87,12 @@ impl<W: Write> Parameter<Encoder<W>> for deflate::CompressionOptions {
     }
 }
 
+impl <W: Write> Parameter<Encoder<W>> for FilterType {
+    fn set_param(self, this: &mut Encoder<W>) {
+        this.info.filter = self
+    }
+}
+
 /// PNG writer
 pub struct Writer<W: Write> {
     w: W,
@@ -134,7 +140,7 @@ impl<W: Write> Writer<W> {
             return Err(EncodingError::Format(message.into()));
         }
         let mut zlib = deflate::write::ZlibEncoder::new(Vec::new(), self.info.compression);
-        let filter_method = FilterType::Sub;
+        let filter_method = self.info.filter;
         for line in data.chunks(in_len) {
             current.copy_from_slice(&line);
             try!(zlib.write_all(&[filter_method as u8]));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -60,5 +60,6 @@ pub use common::*;
 pub use decoder::{Decoder, Reader, OutputInfo, StreamingDecoder, Decoded, DecodingError, Limits};
 #[cfg(feature = "png-encoding")]
 pub use encoder::{Encoder, Writer, EncodingError};
+pub use filter::FilterType;
 
 pub use traits::{Parameter, HasParameters};


### PR DESCRIPTION
> For context, refer to this [issue](https://github.com/PistonDevelopers/image/issues/849)

- Compression and filter fields added to existing Info struct, since that seems to be it's purpose.
- Default to `deflate::Compression::Fast` and `filter::FilterType::Sub` to maintain backward compatible output.
- Compression enum is defined by deflate crate.

Implemented as a generic setter through the `Parameter` trait.
This simplifies the usage and conforms to the established
pattern.

One caveat with this approach is requiring the caller to import
`deflate` and `png::HasParameters`.

Example use of the api:

```rust
use std::io::prelude::*;
use png::{self, HasParameters};
use deflate;

/// Encodes the image ```image```
/// that has dimensions ```width``` and ```height```
/// and ```ColorType``` ```c```
pub fn encode<W: Write>(
    w: W,
    data: &[u8],
    width: u32,
    height: u32,
    ct: png::ColorType,
    bits: png::BitDepth,
) -> io::Result<()> {
    let mut encoder = png::Encoder::new(w, width, height);
    encoder
        .set(ct)
        .set(bits)
        // Note that we can now set the compression level and filter type.
        // If we don't manually set these, they default to
        // `deflate::Compression::Fast` and `png::FilterType::Sub` respectively,
        // which were the previously hard-coded values.
        .set(deflate::CompressionOptions::default())
        .set(png::FilterType::Paeth);
    let mut writer = encoder.write_header()?;
    writer.write_image_data(data).map_err(|e| e.into())
}
```