### PR TITLE
Remove instances of unsafe code

### DIFF
--- a/examples/pngcheck.rs
+++ b/examples/pngcheck.rs
@@ -170,7 +170,7 @@ fn check_image<P: AsRef<Path>>(c: Config, fname: P) -> io::Result<()> {
             }));
             buf = &data[..n];
         }
-        match decoder.update(buf) {
+        match decoder.update(buf, &mut Vec::new()) {
             Ok((_, ImageEnd)) => {
                 if !have_idat {
                     try!(display_error(png::DecodingError::Format("IDAT chunk missing".into())));
@@ -259,7 +259,7 @@ fn check_image<P: AsRef<Path>>(c: Config, fname: P) -> io::Result<()> {
                             _ => ()
                         }
                     }
-                    ImageData(_) => {
+                    ImageData => {
                         //println!("got {} bytes of image data", data.len())
                     }
                     ChunkComplete(_, type_str) if c.verbose => {

--- a/src/common.rs
+++ b/src/common.rs
@@ -91,7 +91,7 @@ impl Unit {
 }
 
 /// Frame control information
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct FrameControl {
     /// Sequence number of the animation chunk, starting from 0
     pub sequence_number: u32,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,7 +41,7 @@
 //! ```
 //!
 //#![cfg_attr(test, feature(test))]
-
+#![feature(nll)]
 #[macro_use] extern crate bitflags;
 
 extern crate num_iter;


### PR DESCRIPTION
This commit changes the interface of StreamingDecoder to not return references
to internal state. This makes it much easier to implement in a way that
satisfies the borrow checker, without resorting to unsafe.

It isn't completely clear whether this change is completely desirable because it
can incur additional copying overhead, but probably won't for common use cases.