### PR TITLE
Bump deflate to 0.7.12

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,10 @@
 language: rust
-rust:
-  - stable
-  - nightly
+matrix:
+  include:
+    - rust: stable
+    - rust: nightly
+    - rust: nightly
+      env: FLAGS="-Z minimal-versions"
 script:
-  - cargo build -v
-  - cargo doc -v
-
+  - cargo build -v $FLAGS
+  - cargo doc -v $FLAGS

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ exclude = [
 
 [dependencies]
 inflate = "0.4.2"
-deflate = { version = "0.7.2", optional = true }
+deflate = { version = "0.7.12", optional = true }
 num-iter = "0.1.32"
 bitflags = "1.0"
 


### PR DESCRIPTION
CompressionOptions::huffman_only doesn't exist in deflate 0.7.2.