### PR TITLE
Add a streaming writer

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -59,7 +59,7 @@ mod utils;
 pub use crate::common::*;
 pub use crate::decoder::{Decoder, Reader, OutputInfo, StreamingDecoder, Decoded, DecodingError, Limits};
 #[cfg(feature = "png-encoding")]
-pub use crate::encoder::{Encoder, Writer, EncodingError};
+pub use crate::encoder::{Encoder, Writer, StreamWriter, EncodingError};
 pub use crate::filter::FilterType;
 
 pub use crate::traits::{Parameter, HasParameters};


### PR DESCRIPTION
This adds a streaming png writer so that you can create images that do not fit in memory. I choose to not update `Writer::write_image_data` as the `StreamWriter` has a few layers of buffering that may reduce performance a little bit. I selected a default chunk size of 4k, this number was a bit out of thin air, however there are only a few extra bytes per chunk so I don't think it will be a problem.

Fixes #75