### PR TITLE
Update deflate minimum version to reflect reality.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ exclude = [
 
 [dependencies]
 inflate = "0.4.2"
-deflate = { version = "0.7.2", optional = true }
+deflate = { version = "0.7.12", optional = true }
 num-iter = "0.1.32"
 bitflags = "1.0"
 


### PR DESCRIPTION
Without this change, any project using an older version of deflate receives this confusing error when switching to 0.14:
```
error[E0599]: no function or associated item named `huffman_only` found for type `encoder::deflate::CompressionOptions` in the current scope
   --> /Users/jdm/.cargo/registry/src/github.com-1ecc6299db9ec823/png-0.14.0/src/common.rs:159:66
    |
159 |             Compression::Huffman => deflate::CompressionOptions::huffman_only(),
    |                                     -----------------------------^^^^^^^^^^^^
    |                                     |
    |                                     function or associated item not found in `encoder::deflate::CompressionOptions`

error[E0599]: no function or associated item named `rle` found for type `encoder::deflate::CompressionOptions` in the current scope
   --> /Users/jdm/.cargo/registry/src/github.com-1ecc6299db9ec823/png-0.14.0/src/common.rs:160:62
    |
160 |             Compression::Rle => deflate::CompressionOptions::rle(),
    |                                 -----------------------------^^^
    |                                 |
    |                                 function or associated item not found in `encoder::deflate::CompressionOptions`
```