### PR TITLE
Update `image-png` to 0.14.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,8 @@ language: rust
 matrix:
   include:
     - rust: stable
+    - rust: stable
+      env: FLAGS="--no-default-features"
     - rust: nightly
     - rust: nightly
       env: FLAGS="-Z minimal-versions"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "png"
-version = "0.14.0"
+version = "0.14.1"
 license = "MIT/Apache-2.0"
 description = "PNG decoding and encoding library in pure Rust"
 authors = ["nwin <nwin@users.noreply.github.com>"]


### PR DESCRIPTION
That release fixes #107 (accidentally pushed without PR in c2b57a52ebad8308c4c01860038730f7e88ec1c5) and introduces a new travis configuration to test a build without features in the future.