### PR TITLE
Fix pngcheck and travis tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,3 +10,4 @@ matrix:
 script:
   - cargo build -v $FLAGS
   - cargo doc -v $FLAGS
+  - cargo test -v $FLAGS


### PR DESCRIPTION
Closes #111 and the associated error in tests. Use the opportunity to 
rework some code flow, avoiding deeply nested loops and the need
for ad-hoc lambda function that is instantly called for error handling.